### PR TITLE
Fix Currency

### DIFF
--- a/src/SummaryTable.js
+++ b/src/SummaryTable.js
@@ -71,7 +71,7 @@ const SummaryTable = ({ data, pivot, group, rows, isCurrency, ...props }) => {
                     {_.startCase(k)}
                   </span>
                 ) : k ? (
-                  formatCurrency({ number: k })
+                  formatCurrency({ number: k / 100 })
                 ) : (
                   <span>&nbsp;</span>
                 )

--- a/src/util.js
+++ b/src/util.js
@@ -235,4 +235,4 @@ export const formatCurrency = ({
     style: 'currency',
     currency,
     ...rest
-  }).format(_.toNumber(number) / 100)
+  }).format(_.toNumber(number))


### PR DESCRIPTION
### Description 
- @doug-patterson I dug through my previous commit history and found where I went wrong. The searchkit already had the `/100` baked in to the `formatCurrency` function, I think because the summaryTable numbers needed it that way? During my previous PR work, I beefed that function up and used it elsewhere in the charts assuming the numbers were the same, which I now see they're not. This pr removes the hard-coded division and moves it to the summaryTable. We probably should make the division of numbers consistent so the summaryTable doesn't have to set it. Sound right? 