### PR TITLE
Make charts animate

### DIFF
--- a/src/Charts.js
+++ b/src/Charts.js
@@ -4,40 +4,6 @@ import FieldStats from './FieldStats'
 import SummaryTable from './SummaryTable'
 import TotalsBar from './TotalsBar'
 
-let reloaded = false
-
-const ChartSizer = ({ children, chartWidths, ...props }) => {
-  const [hasWidth, setHasWidth] = React.useState(
-    !!chartWidths.current[props.chartKey]
-  )
-
-  React.useEffect(() => {
-    const resize = () => {
-      const containerWidth = document.querySelectorAll(
-        `.fmr-chart.${props.chartKey}`
-      )[0]?.clientWidth
-      chartWidths.current = {
-        ...chartWidths.current,
-        [props.chartKey]: containerWidth || 480
-      }
-      setHasWidth(true)
-    }
-    if (!hasWidth) {
-      resize()
-    }
-    const reloader = () => {
-      if (!reloaded) {
-        window.location.reload()
-      }
-      reloaded = true
-    }
-    window.addEventListener('resize', reloader)
-    window.addEventListener('orientationchange', reloader)
-  }, [chartWidths, hasWidth, props.chartKey])
-
-  return hasWidth && <>{children}</>
-}
-
 const Charts = ({
   charts,
   chartWidths,
@@ -67,19 +33,19 @@ const Charts = ({
           key={chart.key}
           style={{ gridArea: chart.key }}
         >
-          {!chart.hideLabel && <h2>{_.toString(chart.label) || _.startCase(chart.key)}</h2>}
-          <ChartSizer chartWidths={chartWidths} chartKey={chart.key}>
-            <Component
-              {..._.omit(['key'], chart)}
-              chartKey={chart.key}
-              chartWidths={chartWidths}
-              data={chartData ? chartData[chart.key] : []}
-              schema={schema}
-              schemas={schemas}
-              UIComponents={UIComponents}
-              height={_.toNumber(chart.height) || 280}
-            />
-          </ChartSizer>
+          {!chart.hideLabel && (
+            <h2>{_.toString(chart.label) || _.startCase(chart.key)}</h2>
+          )}
+          <Component
+            {..._.omit(['key'], chart)}
+            chartKey={chart.key}
+            chartWidths={chartWidths}
+            data={chartData ? chartData[chart.key] : []}
+            schema={schema}
+            schemas={schemas}
+            UIComponents={UIComponents}
+            height={_.toNumber(chart.height) || 280}
+          />
         </div>
       )
     }, charts)}

--- a/src/DefaultUIClientComponents.js
+++ b/src/DefaultUIClientComponents.js
@@ -3,10 +3,10 @@
 import React from 'react'
 import _ from 'lodash/fp'
 import useOutsideClick from './hooks/useOutsideClick'
-import { Line } from '@nivo/line'
-import { Calendar } from '@nivo/calendar'
-import { Pie } from '@nivo/pie'
-import { Bar } from '@nivo/bar'
+import { ResponsiveLine } from '@nivo/line'
+import { ResponsiveCalendar } from '@nivo/calendar'
+import { ResponsivePie } from '@nivo/pie'
+import { ResponsiveBar } from '@nivo/bar'
 import { formatCurrency } from './util'
 
 const americanDate = _.flow(
@@ -140,69 +140,83 @@ export const DateLineSingle = ({
   yLabel,
   isCurrency,
   height,
-  chartWidths,
-  chartKey,
   colors,
-  currency
-}) => (
-  <Line
-    data={americanDates(data)}
-    curve="linear"
-    width={chartWidths.current[chartKey]}
-    height={height}
-    animate={false}
-    colors={colors ? colors : { scheme: 'set2' }}
-    margin={{ top: 50, right: 60, bottom: 50, left: 60 }}
-    xScale={{ type: 'point' }} // need to figure point v linear somehow
-    yScale={{
-      type: 'linear',
-      min: _.minBy('y', data?.results),
-      max: 'auto',
-      stacked: true,
-      reverse: false
-    }}
-    enableArea={true}
-    enablePoints={false}
-    yFormat={value => (isCurrency ? formatCurrency({ amount: value, currency, minimumFractionDigits: 0 }) : value)}
-    axisTop={null}
-    axisRight={null}
-    axisBottom={{
-      orient: 'bottom',
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: -20,
-      legend: xLabel,
-      legendOffset: 36,
-      legendPosition: 'middle'
-    }}
-    axisLeft={{
-      orient: 'left',
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: 0,
-      legend: yLabel,
-      legendOffset: -50,
-      legendPosition: 'middle',
-      format: value =>
-        isCurrency &&
-        formatCurrency({ amount: value, currency, minimumFractionDigits: 0 })
-    }}
-    pointSize={10}
-    pointColor={{ theme: 'background' }}
-    pointBorderWidth={2}
-    pointBorderColor={{ from: 'serieColor' }}
-    pointLabelYOffset={-12}
-    useMesh={true}
-    tooltip={({ point }) => (
-      <div style={{ padding: 4, backgroundColor: 'white' }}>
-        <b>{point?.data?.x}</b>:{' '}
-        {isCurrency
-          ? formatCurrency({ amount: point?.data?.y, currency, minimumFractionDigits: 0 })
-          : point?.data?.y}
-      </div>
-    )}
-  />
-)
+  currency,
+  margins = { top: 50, right: 60, bottom: 50, left: 60 }
+}) => {
+  return (
+    <ResponsiveLine
+      data={americanDates(data)}
+      curve="linear"
+      animate={true}
+      height={height}
+      colors={colors ? colors : { scheme: 'set2' }}
+      margin={{
+        ...margins
+      }}
+      xScale={{ type: 'point' }} // need to figure point v linear somehow
+      yScale={{
+        type: 'linear',
+        min: _.minBy('y', data?.results),
+        max: 'auto',
+        stacked: true,
+        reverse: false
+      }}
+      enableArea={true}
+      enablePoints={false}
+      yFormat={value =>
+        isCurrency
+          ? formatCurrency({
+              amount: value,
+              currency,
+              minimumFractionDigits: 0
+            })
+          : value
+      }
+      axisTop={null}
+      axisRight={null}
+      axisBottom={{
+        orient: 'bottom',
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: -20,
+        legend: xLabel,
+        legendOffset: 36,
+        legendPosition: 'middle'
+      }}
+      axisLeft={{
+        orient: 'left',
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: 0,
+        legend: yLabel,
+        legendOffset: -50,
+        legendPosition: 'middle',
+        format: value =>
+          isCurrency &&
+          formatCurrency({ amount: value, currency, minimumFractionDigits: 0 })
+      }}
+      pointSize={10}
+      pointColor={{ theme: 'background' }}
+      pointBorderWidth={2}
+      pointBorderColor={{ from: 'serieColor' }}
+      pointLabelYOffset={-12}
+      useMesh={true}
+      tooltip={({ point }) => (
+        <div style={{ padding: 4, backgroundColor: 'white' }}>
+          <b>{point?.data?.x}</b>:{' '}
+          {isCurrency
+            ? formatCurrency({
+                amount: point?.data?.y,
+                currency,
+                minimumFractionDigits: 0
+              })
+            : point?.data?.y}
+        </div>
+      )}
+    />
+  )
+}
 
 export const DateLineMultiple = ({
   data,
@@ -212,63 +226,65 @@ export const DateLineMultiple = ({
   yLabel,
   isCurrency,
   height,
-  chartWidths,
-  chartKey
+  margins = { top: 50, right: 60, bottom: 50, left: 60 }
 }) => (
-  <Line
-    data={americanDates(
-      _.map(d => ({ ...d, data: _.map(_.omit('group'), d.data) }), data)
-    )}
-    curve="linear"
-    width={chartWidths.current[chartKey]}
-    height={height}
-    animate={false}
-    colors={{ scheme: 'set2' }}
-    margin={{ top: 50, right: 60, bottom: 50, left: 60 }}
-    xScale={{ type: 'point' }} // need to figure point v linear somehow
-    yScale={{
-      type: 'linear',
-      min: _.minBy('y', data?.results),
-      max: 'auto',
-      stacked: true,
-      reverse: false
-    }}
-    enableArea={true}
-    enablePoints={false}
-    yFormat={`>-${isCurrency ? '$' : ''},.2r`}
-    axisTop={null}
-    axisRight={null}
-    axisBottom={{
-      orient: 'bottom',
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: -20,
-      legend: xLabel || _.startCase(x),
-      legendOffset: 36,
-      legendPosition: 'middle'
-    }}
-    axisLeft={{
-      orient: 'left',
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: 0,
-      legend: yLabel || _.startCase(y),
-      legendOffset: -50,
-      legendPosition: 'middle'
-    }}
-    pointSize={10}
-    pointColor={{ theme: 'background' }}
-    pointBorderWidth={2}
-    pointBorderColor={{ from: 'serieColor' }}
-    pointLabelYOffset={-12}
-    useMesh={true}
-    tooltip={({ point }) => (
-      <div style={{ padding: 4, backgroundColor: 'white' }}>
-        <b>{point?.data?.x}</b>: {isCurrency ? '$' : ''}
-        {point?.data?.y}
-      </div>
-    )}
-  />
+  <div className="date-line-multiple">
+    <ResponsiveLine
+      data={americanDates(
+        _.map(d => ({ ...d, data: _.map(_.omit('group'), d.data) }), data)
+      )}
+      curve="linear"
+      animate={true}
+      height={height}
+      colors={{ scheme: 'set2' }}
+      margin={{
+        ...margins
+      }}
+      xScale={{ type: 'point' }} // need to figure point v linear somehow
+      yScale={{
+        type: 'linear',
+        min: _.minBy('y', data?.results),
+        max: 'auto',
+        stacked: true,
+        reverse: false
+      }}
+      enableArea={true}
+      enablePoints={false}
+      yFormat={`>-${isCurrency ? '$' : ''},.2r`}
+      axisTop={null}
+      axisRight={null}
+      axisBottom={{
+        orient: 'bottom',
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: -20,
+        legend: xLabel || _.startCase(x),
+        legendOffset: 36,
+        legendPosition: 'middle'
+      }}
+      axisLeft={{
+        orient: 'left',
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: 0,
+        legend: yLabel || _.startCase(y),
+        legendOffset: -50,
+        legendPosition: 'middle'
+      }}
+      pointSize={10}
+      pointColor={{ theme: 'background' }}
+      pointBorderWidth={2}
+      pointBorderColor={{ from: 'serieColor' }}
+      pointLabelYOffset={-12}
+      useMesh={true}
+      tooltip={({ point }) => (
+        <div style={{ padding: 4, backgroundColor: 'white' }}>
+          <b>{point?.data?.x}</b>: {isCurrency ? '$' : ''}
+          {point?.data?.y}
+        </div>
+      )}
+    />
+  </div>
 )
 
 export const DateTimeLine = ({
@@ -277,19 +293,23 @@ export const DateTimeLine = ({
   xLabel,
   yLabel,
   height,
-  chartWidths,
-  chartKey,
   colors,
-  currency
+  currency,
+  margins = { top: 50, right: 110, bottom: 50, left: 60 }
 }) => (
-  <Line
-    data={isCurrency ? formatCurrency({ amount: data, currency, minimumFractionDigits: 0 }) : data}
+  <ResponsiveLine
+    data={
+      isCurrency
+        ? formatCurrency({ amount: data, currency, minimumFractionDigits: 0 })
+        : data
+    }
     curve="linear"
+    animate={true}
     height={height}
-    width={chartWidths.current[chartKey]}
-    animate={false}
     colors={colors ? colors : { scheme: 'paired' }}
-    margin={{ top: 50, right: 110, bottom: 50, left: 60 }}
+    margin={{
+      ...margins
+    }}
     xScale={{ type: 'point' }}
     yScale={{
       type: 'linear',
@@ -298,7 +318,11 @@ export const DateTimeLine = ({
       stacked: true,
       reverse: false
     }}
-    yFormat={value => (isCurrency ? formatCurrency({ amount: value, currency, minimumFractionDigits: 0 }) : value)}
+    yFormat={value =>
+      isCurrency
+        ? formatCurrency({ amount: value, currency, minimumFractionDigits: 0 })
+        : value
+    }
     axisTop={null}
     axisRight={null}
     axisBottom={{
@@ -387,19 +411,19 @@ export const QuantityByPeriodCalendar = ({
   isCurrency,
   onClick,
   height,
-  chartWidths,
-  chartKey,
-  colors
+  colors,
+  margins = { top: 20, right: 20, bottom: 20, left: 20 }
 }) => (
-  <Calendar
+  <ResponsiveCalendar
     data={fixDates(data)}
     height={height}
-    width={chartWidths.current[chartKey]}
     from={_.flow(_.first, _.get('day'))(data)}
     to={_.flow(_.last, _.get('day'))(data)}
     emptyColor="#eeeeee"
     colors={colors ? colors : ['#61cdbb', '#97e3d5', '#e8c1a0', '#f47560']}
-    margin={{ top: 0, right: 40, bottom: 0, left: 40 }}
+    margin={{
+      ...margins
+    }}
     yearSpacing={40}
     //monthSpacing={10}
     monthBorderColor="#ffffff"
@@ -433,8 +457,8 @@ export const TopNPie = ({
   schema,
   legend,
   height,
-  chartWidths,
-  chartKey
+  chartKey,
+  margins = { top: 50, right: 30, bottom: 50, left: 30 }
 }) => {
   const getId = uniqueIdMaker({})
 
@@ -454,11 +478,10 @@ export const TopNPie = ({
   }, data)
 
   return (
-    <Pie
+    <ResponsivePie
       data={data}
       height={height}
-      width={chartWidths.current[chartKey]}
-      margin={{ top: 50, right: 110, bottom: 50, left: 60 }}
+      margin={{ ...margins }}
       innerRadius={0.5}
       padAngle={0.7}
       cornerRadius={3}
@@ -517,94 +540,100 @@ export const DayOfWeekSummaryBars = ({
   group,
   isCurrency,
   height,
-  chartWidths,
-  chartKey,
   colors,
   enableLabel = true,
   label,
   includeLegends = true,
-  currency
-}) => (
-  <Bar
-    data={data}
-    width={chartWidths.current[chartKey]}
-    label={label}
-    height={height}
-    enableLabel={enableLabel}
-    layout="vertical"
-    indexBy="id"
-    animate={false}
-    keys={_.flow(_.map(_.keys), _.flatten, _.uniq, _.without(['id']))(data)}
-    margin={{ top: 50, right: group ? 130 : 80, bottom: 50, left: 80 }}
-    padding={0.3}
-    xScale={{ type: 'linear' }}
-    colors={colors ? colors : { scheme: 'set2' }}
-    valueFormat={value =>
-      isCurrency
-        ? formatCurrency({ amount: value, currency, minimumFractionDigits: 0 })
-        : value
-    }
-    borderColor={{
-      from: 'color',
-      modifiers: [['darker', 1.6]]
-    }}
-    axisTop={null}
-    axisRight={null}
-    axisBottom={{
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: -20,
-      legend: xLabel,
-      legendPosition: 'middle',
-      legendOffset: 36
-    }}
-    axisLeft={{
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: 0,
-      legend: yLabel,
-      legendPosition: 'middle',
-      legendOffset: -70,
-      format: value =>
-        isCurrency &&
-        formatCurrency({ amount: value, currency, minimumFractionDigits: 0 })
-    }}
-    labelSkipWidth={12}
-    labelSkipHeight={12}
-    labelTextColor={{
-      from: 'color',
-      modifiers: [['darker', 1.6]]
-    }}
-    {...(group && includeLegends
-      ? {
-          legends: [
-            {
-              dataFrom: 'keys',
-              anchor: 'bottom-right',
-              direction: 'column',
-              justify: false,
-              translateX: 120,
-              translateY: 0,
-              itemsSpacing: 2,
-              itemWidth: 100,
-              itemHeight: 20,
-              itemDirection: 'left-to-right',
-              itemOpacity: 0.85,
-              symbolSize: 20,
-              effects: [
-                {
-                  on: 'hover',
-                  style: {
-                    itemOpacity: 1
+  currency,
+  margins = { top: 50, right: group ? 130 : 80, bottom: 50, left: 80 }
+}) => {
+  return (
+    <ResponsiveBar
+      data={data}
+      label={label}
+      enableLabel={enableLabel}
+      height={height}
+      layout="vertical"
+      indexBy="id"
+      animate={true}
+      keys={_.flow(_.map(_.keys), _.flatten, _.uniq, _.without(['id']))(data)}
+      margin={{
+        ...margins
+      }}
+      padding={0.3}
+      xScale={{ type: 'linear' }}
+      colors={colors ? colors : { scheme: 'set2' }}
+      valueFormat={value =>
+        isCurrency
+          ? formatCurrency({
+              amount: value,
+              currency,
+              minimumFractionDigits: 0
+            })
+          : value
+      }
+      borderColor={{
+        from: 'color',
+        modifiers: [['darker', 1.6]]
+      }}
+      axisTop={null}
+      axisRight={null}
+      axisBottom={{
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: -20,
+        legend: xLabel,
+        legendPosition: 'middle',
+        legendOffset: 36
+      }}
+      axisLeft={{
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: 0,
+        legend: yLabel,
+        legendPosition: 'middle',
+        legendOffset: -70,
+        format: value =>
+          isCurrency &&
+          formatCurrency({ amount: value, currency, minimumFractionDigits: 0 })
+      }}
+      labelSkipWidth={12}
+      labelSkipHeight={12}
+      labelTextColor={{
+        from: 'color',
+        modifiers: [['darker', 1.6]]
+      }}
+      {...(group && includeLegends
+        ? {
+            legends: [
+              {
+                dataFrom: 'keys',
+                anchor: 'bottom-right',
+                direction: 'column',
+                justify: false,
+                translateX: 120,
+                translateY: 0,
+                itemsSpacing: 2,
+                itemWidth: 100,
+                itemHeight: 20,
+                itemDirection: 'left-to-right',
+                itemOpacity: 0.85,
+                symbolSize: 20,
+                effects: [
+                  {
+                    on: 'hover',
+                    style: {
+                      itemOpacity: 1
+                    }
                   }
-                }
-              ]
-            }
-          ]
-        }
-      : {})}
-  />
-)
+                ]
+              }
+            ]
+          }
+        : {})}
+    />
+  )
+}
 
 const addZeroHours = hours =>
   _.map(x => _.find({ x }, hours) || { x, y: 0 }, _.range(0, 24))
@@ -635,83 +664,98 @@ export const HourOfDaySummaryLine = ({
   yLabel,
   group,
   height,
-  chartWidths,
-  chartKey,
   colors,
   includeLegends = true,
-  currency
-}) => (
-  <Line
-    data={includeAllHours(data)}
-    width={chartWidths.current[chartKey]}
-    height={height}
-    curve="linear"
-    colors={colors ? colors : { scheme: 'paired' }}
-    margin={{ top: 50, right: group ? 130 : 80, bottom: 50, left: 80 }}
-    xScale={{ type: 'point' }}
-    yScale={{
-      type: 'linear',
-      min: 'auto',
-      max: 'auto',
-      stacked: true,
-      reverse: false
-    }}
-    enableArea={true}
-    enablePoints={false}
-    yFormat={value => (isCurrency ? formatCurrency({ amount: value, currency, minimumFractionDigits: 0 }) : value)}
-    axisTop={null}
-    axisRight={null}
-    axisBottom={{
-      orient: 'bottom',
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: -45,
-      legend: xLabel,
-      legendOffset: 40,
-      legendPosition: 'middle'
-    }}
-    axisLeft={{
-      orient: 'left',
-      tickSize: 5,
-      tickPadding: 5,
-      tickRotation: 0,
-      legend: yLabel,
-      legendOffset: -50,
-      legendPosition: 'middle',
-      format: value =>
-        isCurrency &&
-        formatCurrency({ amount: value, currency, minimumFractionDigits: 0 })
-    }}
-    useMesh={true}
-    {...(group && includeLegends
-      ? {
-          legends: [
-            {
-              anchor: 'bottom-right',
-              direction: 'column',
-              justify: false,
-              translateX: 100,
-              translateY: 0,
-              itemsSpacing: 0,
-              itemDirection: 'left-to-right',
-              itemWidth: 80,
-              itemHeight: 20,
-              itemOpacity: 0.75,
-              symbolSize: 12,
-              symbolShape: 'circle',
-              symbolBorderColor: 'rgba(0, 0, 0, .5)',
-              effects: [
-                {
-                  on: 'hover',
-                  style: {
-                    itemBackground: 'rgba(0, 0, 0, .03)',
-                    itemOpacity: 1
+  currency,
+  margins = { top: 50, right: group ? 130 : 80, bottom: 50, left: 80 }
+}) => {
+  return (
+    <ResponsiveLine
+      data={includeAllHours(data)}
+      curve="linear"
+      animate={true}
+      height={height}
+      colors={colors ? colors : { scheme: 'paired' }}
+      margin={{
+        ...margins
+      }}
+      xScale={{ type: 'point' }}
+      yScale={{
+        type: 'linear',
+        min: 'auto',
+        max: 'auto',
+        stacked: true,
+        reverse: false
+      }}
+      enableArea={true}
+      enablePoints={false}
+      yFormat={value =>
+        isCurrency
+          ? formatCurrency({
+              amount: value,
+              currency,
+              minimumFractionDigits: 0
+            })
+          : value
+      }
+      axisTop={null}
+      axisRight={null}
+      axisBottom={{
+        orient: 'bottom',
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: -45,
+        legend: xLabel,
+        legendOffset: 40,
+        legendPosition: 'middle'
+      }}
+      axisLeft={{
+        orient: 'left',
+        tickSize: 5,
+        tickPadding: 5,
+        tickRotation: 0,
+        legend: yLabel,
+        legendOffset: -50,
+        legendPosition: 'middle',
+        format: value =>
+          isCurrency &&
+          formatCurrency({
+            amount: value,
+            currency,
+            minimumFractionDigits: 0
+          })
+      }}
+      useMesh={true}
+      {...(group && includeLegends
+        ? {
+            legends: [
+              {
+                anchor: 'bottom-right',
+                direction: 'column',
+                justify: false,
+                translateX: 100,
+                translateY: 0,
+                itemsSpacing: 0,
+                itemDirection: 'left-to-right',
+                itemWidth: 80,
+                itemHeight: 20,
+                itemOpacity: 0.75,
+                symbolSize: 12,
+                symbolShape: 'circle',
+                symbolBorderColor: 'rgba(0, 0, 0, .5)',
+                effects: [
+                  {
+                    on: 'hover',
+                    style: {
+                      itemBackground: 'rgba(0, 0, 0, .03)',
+                      itemOpacity: 1
+                    }
                   }
-                }
-              ]
-            }
-          ]
-        }
-      : {})}
-  />
-)
+                ]
+              }
+            ]
+          }
+        : {})}
+    />
+  )
+}

--- a/src/Facet.js
+++ b/src/Facet.js
@@ -15,63 +15,71 @@ const Facet = ({
   currentInput = {},
   hasOptionSearch
 }) => {
-    let [optionSearch, setOptionSearch] = React.useState(
-      _.has(`${title}.optionSearch`, currentInput.current)
-        ? _.get(`${title}.optionSearch`, currentInput.current)
-        : ''
-    )
-    return <UIComponents.CardBody>
-    <div
-      className="fmr-facet__wrapper"
-      style={{ display: 'flex', flexDirection: 'column' }}
-    >
-      {hasOptionSearch && <div className="fmr-facet__option-search">
-        <UIComponents.Input
-          type="text"
-          placeholder={'Search Options'}
-          focus={_.has(`${title}.optionSearch`, currentInput.current)}
-          {...(onChange
-            ? {
-                onChange: val => {
-                  setOptionSearch(val)
-                  currentInput.current = { [`${title}.optionSearch`]: val }
-                  debouncedOnChange({ optionSearch: val })
-                },
-                value: optionSearch
-              }
-            : {
-                name: `${name}[optionSearch]`,
-                defaultValue: optionSearch
-              })}
-        />
-      </div>}
-      {_.map(
-        ({ _id, checked, count, value, lookup }) => (
-          <React.Fragment key={`${_id}-${checked ? 'checked' : 'unchecked'}`}>
-            <UIComponents.CheckBox
-              layout={layout}
-              checked={checked}
-              textMiddle={display({ ...value, ...lookup, _id })}
-              textRight={count}
+  let [optionSearch, setOptionSearch] = React.useState(
+    _.has(`${title}.optionSearch`, currentInput.current)
+      ? _.get(`${title}.optionSearch`, currentInput.current)
+      : ''
+  )
+  return (
+    <UIComponents.CardBody>
+      <div
+        className="fmr-facet__wrapper"
+        style={{ display: 'flex', flexDirection: 'column' }}
+      >
+        {hasOptionSearch && (
+          <div
+            className={`fmr-facet__option-search fmr-facet__option-search--${layout}`}
+          >
+            <UIComponents.Input
+              type="text"
+              placeholder={'Search Options'}
+              focus={_.has(`${title}.optionSearch`, currentInput.current)}
               {...(onChange
                 ? {
-                    onChange: checked => {
-                      const newValues = checked
-                        ? _.concat(values, _id)
-                        : _.without([_id], values)
-                      onChange({ values: newValues })
-                    }
+                    onChange: val => {
+                      setOptionSearch(val)
+                      currentInput.current = {
+                        [`${title}.optionSearch`]: val
+                      }
+                      debouncedOnChange({ optionSearch: val })
+                    },
+                    value: optionSearch
                   }
                 : {
-                    name: `${title}[${_id}]`
+                    name: `${name}[optionSearch]`,
+                    defaultValue: optionSearch
                   })}
             />
-          </React.Fragment>
-        ),
-        options
-      )}
-    </div>
-  </UIComponents.CardBody>
+          </div>
+        )}
+        {_.map(
+          ({ _id, checked, count, value, lookup }) => (
+            <React.Fragment key={`${_id}-${checked ? 'checked' : 'unchecked'}`}>
+              <UIComponents.CheckBox
+                layout={layout}
+                checked={checked}
+                textMiddle={display({ ...value, ...lookup, _id })}
+                textRight={count}
+                {...(onChange
+                  ? {
+                      onChange: checked => {
+                        const newValues = checked
+                          ? _.concat(values, _id)
+                          : _.without([_id], values)
+                        onChange({ values: newValues })
+                      }
+                    }
+                  : {
+                      name: `${title}[${_id}]`
+                    })}
+              />
+            </React.Fragment>
+          ),
+          options
+        )}
+      </div>
+    </UIComponents.CardBody>
+  )
 }
 
 export default Facet

--- a/src/SearchLayout.js
+++ b/src/SearchLayout.js
@@ -9,6 +9,10 @@ import Results from './Results'
 import Charts from './Charts'
 import Filters from './Filters'
 
+const Layout = ({ layoutStyle, children }) => (
+  <DefaultLayout style={layoutStyle}>{children}</DefaultLayout>
+)
+
 const SearchLayout = ({
   initialSearch,
   initialResults = {},
@@ -44,10 +48,6 @@ const SearchLayout = ({
 
   const UIComponents = _.defaults(DefaultUIComponents, ThemeComponents)
 
-  const Layout = ({ children }) => (
-    <DefaultLayout style={layoutStyle}>{children}</DefaultLayout>
-  )
-
   schemas = addDefaultDisplays(schemas)
   const schema = schemas[initialSearch.collection]
   if (!schema) {
@@ -60,12 +60,10 @@ const SearchLayout = ({
       ...patch
     }
 
-    const [{
-      results,
-      resultsCount: newResultsCount,
-      charts,
-      ...filterResults
-    }, constrainedSearch] = (await execute(updatedSearch)) || {}
+    const [
+      { results, resultsCount: newResultsCount, charts, ...filterResults },
+      constrainedSearch
+    ] = (await execute(updatedSearch)) || {}
 
     if (mode === 'route') {
       return
@@ -84,13 +82,12 @@ const SearchLayout = ({
     setRows(results)
     setResultsCount(_.get('count', newResultsCount) || 0)
     setChartData(charts)
-
     onData()
   }
 
   return (
     <UIComponents.Box>
-      <Layout>
+      <Layout layoutStyle={layoutStyle}>
         <Filters
           filters={search.filters}
           filterOptions={filterOptions}


### PR DESCRIPTION
### Description
- This pr fixes charts not being able to animate and causing unnecessary re-renders (chart flickering). The solution was to move the `Layout` component out of the `SearchLayout` to avoid it from re-rendering every time the filers change. 
- Charts now use Nivo's responsive variant for a better UX.
- PR also adds a chart `margins` props for more granular control from consuming project.