### PR TITLE
Improve chart axis styling, formatting, and fix dropdowns

### DIFF
--- a/src/DefaultUIClientComponents.js
+++ b/src/DefaultUIClientComponents.js
@@ -232,11 +232,10 @@ const addZeroPeriodsToAllLines = period => lines => {
 
 const monthDayYear = _.flow(_.split('/'), _.size, _.eq(3))
 const monthYearOnly = _.flow(_.split('/'), _.size, _.eq(2))
+
 const formatAxisBottomDate = ({ iteratee, start, end }) => {
   if (monthDayYear(iteratee)) {
     const day = format(new Date(iteratee), 'd')
-    start = americanDate(start)
-    end = americanDate(end)
     if (start === iteratee) return format(new Date(start), 'MMM d')
     if (end === iteratee) return format(new Date(end), 'MMM d')
     if (day === '1') return format(new Date(iteratee), 'MMM d')
@@ -259,8 +258,8 @@ const formatTooltipDate = date => {
 }
 
 // date range
-const getFirstDate = _.flow(_.first, _.get('data'), _.first, _.get('x'))
-const getLastDate = _.flow(_.last, _.get('data'), _.last, _.get('x'))
+const getFirstDateAndConvertToAmerican = _.flow(firstXValue, americanDate)
+const getLastDateAndConvertToAmerican = _.flow(lastXValue, americanDate)
 
 export const DateLineSingle = ({
   data,
@@ -317,8 +316,8 @@ export const DateLineSingle = ({
           axisBottom?.formatDate
             ? formatAxisBottomDate({
                 iteratee: value,
-                start: getFirstDate(data),
-                end: getLastDate(data)
+                start: getFirstDateAndConvertToAmerican(_.first(data)),
+                end: getLastDateAndConvertToAmerican(_.first(data))
               })
             : value,
         ...axisBottom
@@ -413,8 +412,8 @@ export const DateLineMultiple = ({
         axisBottom?.formatDate
           ? formatAxisBottomDate({
               iteratee: value,
-              start: getFirstDate(data),
-              end: getLastDate(data)
+              start: getFirstDateAndConvertToAmerican(_.first(data)),
+              end: getLastDateAndConvertToAmerican(_.first(data))
             })
           : value,
       ...axisBottom

--- a/src/FilterDropdown.js
+++ b/src/FilterDropdown.js
@@ -3,24 +3,24 @@
 import React from 'react'
 import _ from 'lodash/fp'
 import ChevronDown from './Icons/ChevronDown'
+import useOutsideClick from './hooks/useOutsideClick'
 
-export const FilterDropdown = ({ filterKey, children, openFilters, openMode }) => {
-  const [isOpen, setIsOpen] = React.useState(
-    _.includes(filterKey, openFilters.current)
+export const FilterDropdown = ({
+  filterKey,
+  children,
+  onlyOneFilterOpenAtAtime
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false)
+  const ref = React.useRef()
+
+  useOutsideClick(ref, () =>
+    onlyOneFilterOpenAtAtime ? setIsOpen(false) : null
   )
 
-  const handleToggle = close => {
-    let newOpenState = close === 'close' ? false : !isOpen
-    openFilters.current = newOpenState
-      ? _.flow(_.concat(filterKey), _.uniq)(openFilters.current)
-      : _.without([filterKey], openFilters.current)
-    setIsOpen(newOpenState)
-  }
-
   return (
-    <div className="fmr-filter-dropdown">
+    <div ref={ref} className="fmr-filter-dropdown">
       <button
-        onClick={handleToggle}
+        onClick={() => setIsOpen(!isOpen)}
         className="fmr-filter-dropdown__button"
       >
         <span className="fmr-filter-dropdown__label">

--- a/src/Filters.js
+++ b/src/Filters.js
@@ -8,7 +8,11 @@ import NumericFilter from './NumericFilter'
 import DateTimeInterval from './DateTimeInterval'
 
 const NoComponent = () => 'no filter found'
-const UseWithHide = () => <div>This fitlter should be used with <code>hide: true</code></div>
+const UseWithHide = () => (
+  <div>
+    This fitlter should be used with <code>hide: true</code>
+  </div>
+)
 
 const getFilterComponent = type =>
   ({
@@ -37,11 +41,12 @@ const updateFilters = filters => idx => patch =>
 // we need to handle the search button better - needs to move up to the main
 // layout and potentially be accompanied by sort controls and column pickers
 
-const DefaultWrapper = ({ filterKey, children, UIComponents }) =>
+const DefaultWrapper = ({ filterKey, children, UIComponents }) => (
   <UIComponents.Card>
     <UIComponents.CardHeader>{_.startCase(filterKey)}</UIComponents.CardHeader>
     <>{children}</>
   </UIComponents.Card>
+)
 
 const unsetOptionSearches = _.map(_.set('optionSearch', ''))
 
@@ -53,7 +58,7 @@ const Filters = ({
   UIComponents,
   runSearch,
   currentInput,
-  openFilters,
+  onlyOneFilterOpenAtAtime,
   layout = 'column',
   Wrapper = DefaultWrapper
 }) => {
@@ -76,44 +81,58 @@ const Filters = ({
         const Component = getFilterComponent(filter.type)
         const FinalWrapper = filter.hide ? React.Fragment : Wrapper
         return (
-          <FinalWrapper openFilters={openFilters} filterKey={filter.key} UIComponents={UIComponents}>
-            {!filter.hide &&<Component
-              key={filter.key}
-              layout={layout}
-              {...(runSearch
-                ? {
-                    onChange: async patch =>
-                      runSearch({
-                        filters: updateFilters(unsetOptionSearches(filters))(idx)(patch),
-                        page: 1
-                      }),
-                    debouncedOnChange: _.debounce(1000, async patch =>
-                      runSearch({
-                        filters: updateFilters(unsetOptionSearches(filters))(idx)(patch),
-                        page: 1
-                      }))
-                  }
-                : {
-                    name: filter.key
-                  })}
-              {..._.omit(['key'], filter)}
-              title={filter.key} 
-              options={_.get(
-                'options',
-                _.find({ key: filter.key }, filterOptions)
-              )}
-              hasOptionSearch={_.isString(filter.optionSearch)}
-              display={
-                filter.prop
-                  ? _.get(
-                      filter.prop,
-                      _.get(filter.field, schema.properties)?.items.properties
-                    )?.display
-                  : _.get(filter.subqueryLocalField || filter.field, schema.properties)?.display
-              }
-              UIComponents={UIComponents}
-              currentInput={currentInput}
-            />}
+          <FinalWrapper
+            onlyOneFilterOpenAtAtime={onlyOneFilterOpenAtAtime}
+            filterKey={filter.key}
+            UIComponents={UIComponents}
+          >
+            {!filter.hide && (
+              <Component
+                key={filter.key}
+                layout={layout}
+                {...(runSearch
+                  ? {
+                      onChange: async patch =>
+                        runSearch({
+                          filters: updateFilters(unsetOptionSearches(filters))(
+                            idx
+                          )(patch),
+                          page: 1
+                        }),
+                      debouncedOnChange: _.debounce(1000, async patch =>
+                        runSearch({
+                          filters: updateFilters(unsetOptionSearches(filters))(
+                            idx
+                          )(patch),
+                          page: 1
+                        })
+                      )
+                    }
+                  : {
+                      name: filter.key
+                    })}
+                {..._.omit(['key'], filter)}
+                title={filter.key}
+                options={_.get(
+                  'options',
+                  _.find({ key: filter.key }, filterOptions)
+                )}
+                hasOptionSearch={_.isString(filter.optionSearch)}
+                display={
+                  filter.prop
+                    ? _.get(
+                        filter.prop,
+                        _.get(filter.field, schema.properties)?.items.properties
+                      )?.display
+                    : _.get(
+                        filter.subqueryLocalField || filter.field,
+                        schema.properties
+                      )?.display
+                }
+                UIComponents={UIComponents}
+                currentInput={currentInput}
+              />
+            )}
           </FinalWrapper>
         )
       }, filters)}

--- a/src/SearchLayout.js
+++ b/src/SearchLayout.js
@@ -22,8 +22,8 @@ const SearchLayout = ({
   execute,
   layoutStyle,
   filterLayout,
+  onlyOneFilterOpenAtAtime,
   FilterWrapper,
-  defaultOpenFilters = [],
   mode = 'feathers',
   onData = _.noop
 }) => {
@@ -44,7 +44,6 @@ const SearchLayout = ({
   const [chartData, setChartData] = React.useState(initialResults.charts)
   const currentInput = React.useRef(null)
   const chartWidths = React.useRef({})
-  const openFilters = React.useRef(defaultOpenFilters)
 
   const UIComponents = _.defaults(DefaultUIComponents, ThemeComponents)
 
@@ -95,7 +94,7 @@ const SearchLayout = ({
           schema={schema}
           UIComponents={UIComponents}
           currentInput={currentInput}
-          openFilters={openFilters}
+          onlyOneFilterOpenAtAtime={onlyOneFilterOpenAtAtime}
           layout={filterLayout}
           {...(FilterWrapper ? { Wrapper: FilterWrapper } : {})}
         >


### PR DESCRIPTION
### Description
- Formats x/y tick values and tooltips (Line and Bar charts), and gives consuming project a couple of options.
- Adds/improves prop options and keeps prop naming closer to the Nivo system.
- Note: I've discovered (and maybe it's already known) that the date picker range only works up to 10 days and that the `Last two years` doesn't work. Also `Last Hour` etc.. will need to be dialed in to show hour ticks. 

- EXTRA: Fixes dropdowns. @doug-patterson the `openFilters` prop/logic is no longer needed. The dropdowns will remain open now (as they do currently) with much less code unless you add the new prop `onlyOneFilterOpenAtAtime`. Please test this in particular and open/check in all kinds of ways to confirm. 