### PR TITLE
Ts conversion for useOutsideClick hook

### DIFF
--- a/src/FilterDropdown.tsx
+++ b/src/FilterDropdown.tsx
@@ -8,19 +8,19 @@ import useOutsideClick from './hooks/useOutsideClick'
 type Props = {
   children: ReactNode
   filterKey: string
-  onlyOneFilterOpenAtAtime: boolean
+  onlyOneFilterOpenAtATime: boolean
 }
 
 export const FilterDropdown = ({
   filterKey,
   children,
-  onlyOneFilterOpenAtAtime
+  onlyOneFilterOpenAtATime
 }: Props) => {
   const [isOpen, setIsOpen] = React.useState(false)
   const ref = React.useRef(null)
 
   useOutsideClick(ref, () =>
-    onlyOneFilterOpenAtAtime ? setIsOpen(false) : null
+    onlyOneFilterOpenAtATime ? setIsOpen(false) : null
   )
 
   return (

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,10 +1,8 @@
-'use client'
+import { RefObject, useEffect } from 'react'
 
-import { useEffect } from 'react'
-
-const useOutsideClick = (ref: any, callback: any) => {
-  const handleClick = (e: any) => {
-    if (ref.current && !ref.current.contains(e.target)) {
+const useOutsideClick = (ref: RefObject<HTMLElement>, callback: () => void) => {
+  const handleClick = (e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) {
       callback()
     }
   }


### PR DESCRIPTION
### Description
- Adds types to the `useOutsideClick` custom hook.
- fixes typo on props
- removes `use client` from the custom hook as it should be implied that wherever hooks are used with `app dir` next13, `use client` will be used.